### PR TITLE
Retrieve token salt and hash from AWS Secret Manager

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,13 @@ jobs:
         sqlite3 -version
         make -version
         make sqlite-db-refresh
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
     - name: Running Tests
       run: "./gradlew test --tests=org.*"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-2
 
     - name: Running Tests
       run: "./gradlew test --tests=org.*"

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     implementation 'org.xerial:sqlite-jdbc:3.8.11.2'
     implementation 'com.vladmihalcea:hibernate-types-52:2.14.0'
     implementation 'org.ga4gh:ga4gh-starter-kit-common:0.5.6'
+    implementation platform('software.amazon.awssdk:bom:2.17.145')
+    implementation 'software.amazon.awssdk:secretsmanager:2.17.145'
 
     testCompileOnly 'org.projectlombok:lombok:1.18.22'
 	testAnnotationProcessor 'org.projectlombok:lombok:1.18.22'

--- a/database/postgresql/add-dev-dataset.sql
+++ b/database/postgresql/add-dev-dataset.sql
@@ -76,14 +76,10 @@ insert into specification_platform values
 
 insert into report_series values (
     '1edb5213-52a2-434f-a7b8-b101fea8fb30',
-    'k4A2I1FUJrbpN70v4FXrrAqwvcamnZyB',
-    'dcaa1ff102a989efeaebef66e950216d86160303689120e9e76d88d4a70bd003', /* plaintext token is K5pLbwScVu8rEoLLj8pRy5Wv7EXTVahn */
     'refget-compliance',
     'org.ga4gh.refget.starterkit'
 ),(
     '483382e9-f92b-466d-9427-154d56a75fcf',
-    'JQhtM8FvjgaQaNbxTFbawJTWFjbdiiSL',
-    '463bdadca28c206693339fcc5465c9885395a7e03deff93ce1e851c5561bae36', /* plaintext token is l0HiRbbpjVDKc6k3tQ2skzROB1oAP2IV */
     'rnaget-compliance',
     'org.ga4gh.rnaget.starterkit'
 );

--- a/database/postgresql/create-tables.sql
+++ b/database/postgresql/create-tables.sql
@@ -107,8 +107,6 @@ CREATE TABLE IF NOT EXISTS summary
 CREATE TABLE IF NOT EXISTS report_series
 (
     id text PRIMARY KEY,
-    token_salt text NOT NULL,
-    token_hash text NOT NULL,
     fk_testbed_id text NOT NULL,
     fk_platform_id text NOT NULL,
     foreign key (fk_testbed_id) references testbed(id),

--- a/database/sqlite/add-dev-dataset.sql
+++ b/database/sqlite/add-dev-dataset.sql
@@ -76,14 +76,10 @@ insert into specification_platform values
 
 insert into report_series values (
     "1edb5213-52a2-434f-a7b8-b101fea8fb30",
-    'k4A2I1FUJrbpN70v4FXrrAqwvcamnZyB',
-    'dcaa1ff102a989efeaebef66e950216d86160303689120e9e76d88d4a70bd003', /* plaintext token is K5pLbwScVu8rEoLLj8pRy5Wv7EXTVahn */
     'refget-compliance',
     'org.ga4gh.refget.starterkit'
 ),(
     "483382e9-f92b-466d-9427-154d56a75fcf",
-    'JQhtM8FvjgaQaNbxTFbawJTWFjbdiiSL',
-    '463bdadca28c206693339fcc5465c9885395a7e03deff93ce1e851c5561bae36', /* plaintext token is l0HiRbbpjVDKc6k3tQ2skzROB1oAP2IV */
     'rnaget-compliance',
     'org.ga4gh.rnaget.starterkit'
 );

--- a/database/sqlite/create-tables.sql
+++ b/database/sqlite/create-tables.sql
@@ -107,8 +107,6 @@ CREATE TABLE IF NOT EXISTS summary
 CREATE TABLE IF NOT EXISTS report_series
 (
     id text PRIMARY KEY,
-    token_salt text NOT NULL,
-    token_hash text NOT NULL,
     fk_testbed_id text NOT NULL,
     fk_platform_id text NOT NULL,
     foreign key (fk_testbed_id) references testbed(id),

--- a/src/main/java/org/ga4gh/testbed/api/app/TestbedApiSpringConfig.java
+++ b/src/main/java/org/ga4gh/testbed/api/app/TestbedApiSpringConfig.java
@@ -32,6 +32,7 @@ import org.ga4gh.testbed.api.model.TestbedVersion;
 import org.ga4gh.testbed.api.utils.hibernate.TestbedApiHibernateUtil;
 import org.ga4gh.testbed.api.utils.requesthandler.report.CreateReportHandler;
 import org.ga4gh.testbed.api.utils.requesthandler.report.ShowReportHandler;
+import org.ga4gh.testbed.api.utils.secretmanager.AwsSecretManagerUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -146,6 +147,14 @@ public class TestbedApiSpringConfig {
     @Bean
     public LoggingUtil loggingUtil() {
         return new LoggingUtil();
+    }
+
+    /* ******************************
+     * SECRETS MANAGER
+     * ****************************** */
+    @Bean
+    public AwsSecretManagerUtil awsSecretManagerUtil() {
+        return new AwsSecretManagerUtil();
     }
 
     /* ******************************

--- a/src/main/java/org/ga4gh/testbed/api/model/ReportSeries.java
+++ b/src/main/java/org/ga4gh/testbed/api/model/ReportSeries.java
@@ -35,14 +35,6 @@ public class ReportSeries implements HibernateEntity<String> {
     @JsonView(SerializeView.Always.class)
     private String id;
 
-    @Column(name = "token_salt", nullable = false)
-    @JsonView(SerializeView.Never.class)
-    private String tokenSalt;
-
-    @Column(name = "token_hash", nullable = false)
-    @JsonView(SerializeView.Never.class)
-    private String tokenHash;
-
     @ManyToOne(fetch = FetchType.EAGER,
                cascade = {CascadeType.PERSIST, CascadeType.MERGE,
                           CascadeType.DETACH, CascadeType.REFRESH})

--- a/src/main/java/org/ga4gh/testbed/api/utils/requesthandler/report/CreateReportHandler.java
+++ b/src/main/java/org/ga4gh/testbed/api/utils/requesthandler/report/CreateReportHandler.java
@@ -1,5 +1,6 @@
 package org.ga4gh.testbed.api.utils.requesthandler.report;
 
+import java.util.HashMap;
 import java.util.UUID;
 
 import org.apache.commons.codec.digest.DigestUtils;
@@ -11,6 +12,7 @@ import org.ga4gh.testbed.api.exception.UnauthorizedException;
 import org.ga4gh.testbed.api.model.Report;
 import org.ga4gh.testbed.api.model.ReportSeries;
 import org.ga4gh.testbed.api.utils.hibernate.TestbedApiHibernateUtil;
+import org.ga4gh.testbed.api.utils.secretmanager.AwsSecretManagerUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import lombok.Getter;
@@ -23,9 +25,13 @@ public class CreateReportHandler extends BasicCreateRequestHandler<String, Repor
     private String reportSeriesId;
     private String reportSeriesToken;
     private Report report;
+    private static final String TESTBED_TOKENS_SECRET_NAME = "ga4gh-testbed-reportseries-tokens";
 
     @Autowired
     TestbedApiHibernateUtil hibernateUtil;
+
+    @Autowired
+    AwsSecretManagerUtil awsSecretManagerUtil;
 
     public CreateReportHandler() {
         super(Report.class);
@@ -47,24 +53,39 @@ public class CreateReportHandler extends BasicCreateRequestHandler<String, Repor
         }
         report.setReportSeries(reportSeries);
 
+        // get the token salt and token hash from AWS SM
+        HashMap<String, String> tokenMap;
+        try  {
+            tokenMap = awsSecretManagerUtil.retrieveSecret(TESTBED_TOKENS_SECRET_NAME);
+        } catch(Exception ex){
+            // TODO: log the original exception message
+            throw new ResourceNotFoundException(String.format("Retrieval of token salt and hash failed for report series id: %s",reportSeriesId));
+        }
+        String tokenSalt = tokenMap.get("token-salt-"+reportSeriesId);
+        String tokenHash = tokenMap.get("token-hash-"+reportSeriesId);
+        if (tokenSalt == null || tokenHash == null){
+            // TODO: log this
+            System.err.println(String.format("token salt or token hash is not available in the secret manager for report series id: %s",reportSeriesId) );
+        }
+
         // calculate the input token hash based on input token and salt
-        // compare the input token hash to the report series's token hash in db
-        String tokenSaltPlaintextAttempt = reportSeriesToken + reportSeries.getTokenSalt();
+        // compare the input token hash to the report series's token hash in the AWS SM
+        String tokenSaltPlaintextAttempt = reportSeriesToken + tokenSalt;
         String hashAttempt = DigestUtils.sha256Hex(tokenSaltPlaintextAttempt);
-        if (! hashAttempt.equals(reportSeries.getTokenHash())) {
+        if (! hashAttempt.equals(tokenHash)) {
             throw new UnauthorizedException("Cannot add Report to ReportSeries: invalid token");
         }
 
         // assign a random UUIDv4 to the report
         report.setId(UUID.randomUUID().toString());
-        
+
         // create object
         try {
             hibernateUtil.createEntityObject(Report.class, report);
         } catch (EntityExistsException ex) {
             throw new ConflictException(ex.getMessage());
         }
-        
+
         return hibernateUtil.readFullReport(report.getId());
     }
 }

--- a/src/main/java/org/ga4gh/testbed/api/utils/secretmanager/AwsSecretManagerUtil.java
+++ b/src/main/java/org/ga4gh/testbed/api/utils/secretmanager/AwsSecretManagerUtil.java
@@ -1,0 +1,121 @@
+package org.ga4gh.testbed.api.utils.secretmanager;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
+import software.amazon.awssdk.services.secretsmanager.model.CreateSecretResponse;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.UpdateSecretRequest;
+import software.amazon.awssdk.services.secretsmanager.model.UpdateSecretResponse;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.stream.Collectors;
+
+
+public class AwsSecretManagerUtil {
+    public static final String REGION = "us-east-1";
+
+    public String createSecret(
+            final String secretName,
+            final String secretKey,
+            final String secretValue,
+            final String secretDescription){
+        // creates a new AWS Secret Manager entry by name = secretName.
+        // This entry will house a key value pair.
+        SecretsManagerClient secretsClient= secretsClient();
+        try {
+
+            String secretKeyValue = String.format("{ \"%s\":\"%s\" }", secretKey, secretValue);
+            CreateSecretRequest createSecretRequest = CreateSecretRequest.builder()
+                    .name(secretName)
+                    .description(secretDescription)
+                    .secretString(secretKeyValue)
+                    .build();
+            CreateSecretResponse createSecretResponse = secretsClient.createSecret(createSecretRequest);
+            secretsClient.close();
+            return createSecretResponse.arn();
+        } catch (Exception ex){
+            secretsClient.close();
+            throw ex;
+        } finally {
+            secretsClient.close();
+        }
+    }
+
+    public HashMap<String, String> retrieveSecret(final String secretName) throws JsonProcessingException {
+        // Retrieves an entry from AWS Secret Manager by name, secretName
+        SecretsManagerClient secretsClient= secretsClient();
+        try {
+            GetSecretValueRequest getSecretValueRequest = GetSecretValueRequest.builder()
+                    .secretId(secretName)
+                    .build();
+            GetSecretValueResponse getSecretValueResponse = null;
+            getSecretValueResponse = secretsClient.getSecretValue(getSecretValueRequest);
+            String secret = null;
+            if (getSecretValueResponse.secretString() != null) {
+                secret = getSecretValueResponse.secretString();
+            } else if (getSecretValueResponse.secretBinary() != null) {
+                secret = new String(Base64.getDecoder().decode(getSecretValueResponse.secretBinary().asByteBuffer()).array());
+            }
+            secretsClient.close();
+            // convert secret string to HashMap<String, String>
+            final ObjectMapper objectMapper = new ObjectMapper();
+            final HashMap<String, String> secretMap = objectMapper.readValue(secret, HashMap.class);
+            return secretMap;
+        } catch(Exception ex){
+            secretsClient.close();
+            throw ex;
+        } finally {
+            secretsClient.close();
+        }
+    }
+
+    public String updateSecret(
+            final String secretName,
+            final String secretKey,
+            final String secretValue,
+            final String secretDescription) throws JsonProcessingException {
+        // Updates an existing SM entry with an additional key vaule pair
+        SecretsManagerClient secretsClient= secretsClient();
+        try {
+
+            // get existing secretMap
+            HashMap<String, String> secretMap = retrieveSecret(secretName);
+
+            // add the new key value pair to the secretMap
+            secretMap.put(secretKey,secretValue);
+
+            // convert the secretMap to a String and update the secret entry with this string
+            String secretKeyValueString = secretMap.keySet().stream()
+                    .map(key -> "\""+key+ "\":\"" + secretMap.get(key)+"\"")
+                    .collect(Collectors.joining(", ", "{", "}"));
+            UpdateSecretRequest updateSecretRequest = UpdateSecretRequest.builder()
+                    .secretId(secretName)
+                    .description(secretDescription)
+                    .secretString(secretKeyValueString)
+                    .build();
+            UpdateSecretResponse updateSecretResponse = secretsClient.updateSecret(updateSecretRequest);
+            secretsClient.close();
+            return updateSecretResponse.arn();
+        } catch (Exception ex){
+            secretsClient.close();
+            throw ex;
+        } finally {
+            secretsClient.close();
+        }
+
+    }
+
+    private SecretsManagerClient secretsClient(){
+        Region region = Region.of(REGION);
+        SecretsManagerClient secretsClient = SecretsManagerClient.builder()
+                .region(region)
+                .build();
+        return secretsClient;
+    }
+
+}

--- a/src/main/java/org/ga4gh/testbed/api/utils/secretmanager/AwsSecretManagerUtil.java
+++ b/src/main/java/org/ga4gh/testbed/api/utils/secretmanager/AwsSecretManagerUtil.java
@@ -21,19 +21,19 @@ public class AwsSecretManagerUtil {
 
     public String createSecret(
             final String secretName,
-            final String secretKey,
-            final String secretValue,
+            final HashMap<String, String> secretKeyVaueMap,
             final String secretDescription){
         // creates a new AWS Secret Manager entry by name = secretName.
-        // This entry will house a key value pair.
+        // This entry will house a set of key value pairs.
         SecretsManagerClient secretsClient= secretsClient();
         try {
-
-            String secretKeyValue = String.format("{ \"%s\":\"%s\" }", secretKey, secretValue);
+            String secretKeyValueString = secretKeyVaueMap.keySet().stream()
+                    .map(key -> "\""+key+ "\":\"" + secretKeyVaueMap.get(key)+"\"")
+                    .collect(Collectors.joining(", ", "{", "}"));
             CreateSecretRequest createSecretRequest = CreateSecretRequest.builder()
                     .name(secretName)
                     .description(secretDescription)
-                    .secretString(secretKeyValue)
+                    .secretString(secretKeyValueString)
                     .build();
             CreateSecretResponse createSecretResponse = secretsClient.createSecret(createSecretRequest);
             secretsClient.close();
@@ -79,7 +79,8 @@ public class AwsSecretManagerUtil {
             final String secretKey,
             final String secretValue,
             final String secretDescription) throws JsonProcessingException {
-        // Updates an existing SM entry with an additional key vaule pair
+        // Updates an existing AWS Secret Manager entry.
+        // If the key already exists, the value is updated or a new key value pair is added.
         SecretsManagerClient secretsClient= secretsClient();
         try {
 

--- a/src/test/java/org/ga4gh/testbed/api/model/ReportSeriesTest.java
+++ b/src/test/java/org/ga4gh/testbed/api/model/ReportSeriesTest.java
@@ -13,8 +13,6 @@ public class ReportSeriesTest {
         return new Object[][] {
             {
                 "1edb5213-52a2-434f-a7b8-b101fea8fb30",
-                "abc",
-                "def",
                 new Testbed() {{
                     setId("refget-compliance");
                 }},
@@ -31,22 +29,17 @@ public class ReportSeriesTest {
     }
 
     @Test(dataProvider = "cases")
-    public void testReportSeries(String id, String tokenSalt, String tokenHash,
-        Testbed testbed, Platform platform, List<Report> reports) {
+    public void testReportSeries(String id, Testbed testbed, Platform platform, List<Report> reports) {
 
         ReportSeries reportSeries = new ReportSeries();
         reportSeries.loadRelations();
 
         reportSeries.setId(id);
-        reportSeries.setTokenSalt(tokenSalt);
-        reportSeries.setTokenHash(tokenHash);
         reportSeries.setTestbed(testbed);
         reportSeries.setPlatform(platform);
         reportSeries.setReports(reports);
 
         Assert.assertEquals(reportSeries.getId(), id);
-        Assert.assertEquals(reportSeries.getTokenSalt(), tokenSalt);
-        Assert.assertEquals(reportSeries.getTokenHash(), tokenHash);
         Assert.assertEquals(reportSeries.getTestbed(), testbed);
         Assert.assertEquals(reportSeries.getPlatform(), platform);
         Assert.assertEquals(reportSeries.getReports(), reports);


### PR DESCRIPTION
- remove token salt, hash from the database. Move them into AWS Secret Manager.
- add helper methods to create, update, retrieve secrets.
- secrets are stored as key-value pairs only and not as strings
- update the GitHub actions workflow to add AWS creds